### PR TITLE
Added searchExpressions and Group joins support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ log/*.log
 tags
 tmp
 npm-debug.log
+
+.idea

--- a/lib/search.js
+++ b/lib/search.js
@@ -369,13 +369,20 @@ this.Searcher = (function() {
                 var name = column.getName();
                 var join = column.getJoin();
                 var value = result.getValue(column);
+                var text = result.getText(column);
                 var joinTitle = join;
 
                 if (join) {
                     if(!(joinTitle in newResult.columns)) newResult.columns[joinTitle] = {};
                     newResult.columns[joinTitle][name] = value;
+                    if(text && text !== value) {
+                        newResult.columns[joinTitle][name  + '.text'] = text;
+                    }
                 } else {
                     newResult.columns[name] = value;
+                    if(text && text !== value) {
+                        newResult.columns[name + '.text'] = text;
+                    }
                 }
             }
             newResultsBlock.push(newResult);

--- a/lib/search.js
+++ b/lib/search.js
@@ -11,7 +11,7 @@
 this.Searcher = (function() {
 
   /** @constructor */
-  function Searcher(recordType, batchSize, lowerBound, searchFilters, searchColumns) {
+  function Searcher(recordType, batchSize, lowerBound, searchFilters, searchColumns, advancedOptions) {
     this.SEARCH_FILTER_NAME_KEY     = 'name';
     this.SEARCH_FILTER_OPERATOR_KEY = 'operator';
     this.SEARCH_FILTER_VALUE_KEY    = 'value';
@@ -37,6 +37,10 @@ this.Searcher = (function() {
     this.searchFilters         = [];
     this.searchColumns         = [];
     this.results               = [];
+    this.advancedOptions       = advancedOptions || {
+      useFilterExpressions: false,
+      groupJoins: false
+    };
 
     intBatchSize = parseInt(this.originalBatchSize);
     if((intBatchSize % 1000) != 0) {
@@ -44,10 +48,18 @@ this.Searcher = (function() {
     }
     this.batchSize = intBatchSize;
 
-    this.createSearchFilters();
-    this.generateLowerBoundFilter();
+    this.createFilters();
     this.createSearchColumns();
     this.generateSortColumn();
+  }
+
+  Searcher.prototype.createFilters = function () {
+      if (this.advancedOptions.useFilterExpressions) {
+          this.searchFilters = this.rawSearchFilters;
+      } else {
+          this.createSearchFilters();
+          this.generateLowerBoundFilter();
+      }
   }
 
   /**
@@ -155,10 +167,10 @@ this.Searcher = (function() {
    * @return {nlobjSearchFilter} The generated search filter
    */
   Searcher.prototype.getSearchFilterObject = function(searchFilterData) {
-    name     = searchFilterData[this.SEARCH_FILTER_NAME_KEY];
-    operator = searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY];
-    value    = searchFilterData[this.SEARCH_FILTER_VALUE_KEY];
-    join     = searchFilterData[this.SEARCH_FILTER_JOIN_KEY] || null;
+    var name     = searchFilterData[this.SEARCH_FILTER_NAME_KEY];
+    var operator = searchFilterData[this.SEARCH_FILTER_OPERATOR_KEY];
+    var value    = searchFilterData[this.SEARCH_FILTER_VALUE_KEY];
+    var join     = searchFilterData[this.SEARCH_FILTER_JOIN_KEY] || null;
 
     filter = NetsuiteToolkit.searchFilter(name, join, operator, value);
     return filter;
@@ -174,8 +186,8 @@ this.Searcher = (function() {
    */
   Searcher.prototype.createSearchColumns = function() {
     for(index in this.rawSearchColumns) {
-      searchColumnData   = this.rawSearchColumns[index];
-      searchColumnObject = this.getSearchColumnObject(searchColumnData);
+      var searchColumnData   = this.rawSearchColumns[index];
+      var searchColumnObject = this.getSearchColumnObject(searchColumnData);
       this.searchColumns.push(searchColumnObject);
     }
   }
@@ -203,9 +215,9 @@ this.Searcher = (function() {
    * @return {nlobjSearchColumn} The generated search column
    */
   Searcher.prototype.getSearchColumnObject = function(searchColumnData) {
-    name = searchColumnData[this.SEARCH_COLUMN_NAME_KEY];
-    join = searchColumnData[this.SEARCH_COLUMN_JOIN_KEY];
-    column = NetsuiteToolkit.searchColumn(name, join);
+    var name = searchColumnData[this.SEARCH_COLUMN_NAME_KEY];
+    var join = searchColumnData[this.SEARCH_COLUMN_JOIN_KEY];
+    var column = NetsuiteToolkit.searchColumn(name, join);
     return column;
   }
 
@@ -328,8 +340,48 @@ this.Searcher = (function() {
    * @return {null}
    */
   Searcher.prototype.appendResults = function(resultsBlock) {
-    this.results = this.results.concat(resultsBlock);
+    if (this.advancedOptions.groupJoins) {
+        this.appendResultsGroupJoins(resultsBlock);
+    } else {
+        this.results = this.results.concat(resultsBlock);
+    }
   }
+
+    /**
+     * Concatenates the given result set onto the result list and group join fields into nested object
+     *
+     * @method
+     * @param {Array} resultsBlock The array containing a set of results from Netsuite
+     * @memberof Searcher
+     * @return {null}
+     */
+    Searcher.prototype.appendResultsGroupJoins = function(resultsBlock) {
+        var newResultsBlock = [];
+        for ( var i = 0; resultsBlock != null && i < resultsBlock.length; i++ )
+        {
+            var newResult = {"id":resultsBlock[i].getId(), "recordtype":resultsBlock[i].getRecordType(), "columns":{}};
+            var result = resultsBlock[i];
+            var columns = result.getAllColumns();
+            var columnLen = columns.length;
+
+            for (var x = 0; x < columnLen; x++) {
+                var column = columns[x];
+                var name = column.getName();
+                var join = column.getJoin();
+                var value = result.getValue(column);
+                var joinTitle = join;
+
+                if (join) {
+                    if(!(joinTitle in newResult.columns)) newResult.columns[joinTitle] = {};
+                    newResult.columns[joinTitle][name] = value;
+                } else {
+                    newResult.columns[name] = value;
+                }
+            }
+            newResultsBlock.push(newResult);
+        }
+        this.results = this.results.concat(newResultsBlock);
+    }
 
   /**
    * Generates a list of params given in the HTTP request
@@ -345,6 +397,8 @@ this.Searcher = (function() {
     params['lower_bound']    = this.originalLowerBound;
     params['search_filters'] = this.rawSearchFilters;
     params['search_columns'] = this.rawSearchColumns;
+    params['advanced_options'] = this.advancedOptions;
+
     return params;
   }
 
@@ -367,7 +421,7 @@ this.Searcher = (function() {
 
 /**
  * The script function that Netsuite will call to execute the Search process
- * 
+ *
  * @method
  * @param {object} request The object representing the HTTP request body
  * @memberof global
@@ -375,7 +429,7 @@ this.Searcher = (function() {
  */
 var searchPostHandler = function(request) {
   searcher = new Searcher(request['record_type'], request['batch_size'], request['lower_bound'],
-                          request['search_filters'], request['search_columns']);
+                          request['search_filters'], request['search_columns'], request['advanced_options']);
   searcher.executeSearch();
   return searcher.reply();
 }

--- a/spec/upsert.spec.js
+++ b/spec/upsert.spec.js
@@ -33,7 +33,7 @@ describe('Upserter', function() {
     });
 
     it('should initialize the reply_list as an empty Array', function() {
-      expect(upserter.reply_list).toEqual([]); 
+      expect(upserter.reply_list).toEqual([]);
     });
 
     it('should initialize the exception to null', function() {
@@ -115,7 +115,7 @@ describe('Upserter', function() {
     });
 
     it('should call formatReply on NetsuiteToolkit', function() {
-      expect(NetsuiteToolkit.formatReply).toHaveBeenCalledWith(upserter.params, upserter.replyList);
+      expect(NetsuiteToolkit.formatReply).toHaveBeenCalledWith(upserter.params, upserter.reply_list);
     });
 
     it('should return the output of formatreply', function() {
@@ -296,7 +296,7 @@ describe('UpsertRequest', function() {
       spyOn(this.fake_processor, 'execute');
       upsert_request.executeSublistProcessor(sublist_one);
     });
-  
+
     it('should call the constructor of NetsuiteToolkit.SublistProcessor', function() {
       expect(NetsuiteToolkit.SublistProcessor).toHaveBeenCalledWith(upsert_request.record,
                                                                     sublist_one);


### PR DESCRIPTION
**Which issue this PR fixes** <!--*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)* -->

Adds ability of grouping joined fields and utilizing filter expressions (OR\AND operators). Options are switched off by default.

**Special notes for your reviewer**: <!--*(optional)*-->
required by netsuite-crm-integration
Original code for grouping has been taken from https://github.com/acumenbrands/rest_suite/pull/31
and simplified a bit

Could be used like this

```
        const query = {
            record_type: recordType,
            batch_size: 5000,
            lower_bound: -9999,
            search_filters: searchFilters,
            search_columns: searchColumns,
            **advanced_options: {
                useFilterExpressions: true,
                groupJoins: true
            })**
        };
```

